### PR TITLE
fix(windows): fixup cgo errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cgo"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Ryan Fowler"]
 description = "A library for build scripts to compile custom Go code"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,22 @@ cgo = "*"
 The following example will statically compile the Go package and instruct
 cargo to link the resulting library (`libexample`).
 
+Not Windows:
+
 ```rust
 fn main() {
     cgo::Build::new()
+        .package("pkg/example/main.go")
+        .build("example");
+}
+```
+
+Windows:
+
+```rust
+fn main() {
+    cgo::Build::new()
+        .build_mode(cgo::BuildMode::CShared)
         .package("pkg/example/main.go")
         .build("example");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,6 +330,7 @@ impl Build {
 ///
 /// Refer to the [Go docs](https://pkg.go.dev/cmd/go#hdr-Build_modes)
 /// for more information.
+/// Notice: Windows support `CShared` only
 #[derive(Clone, Debug, Default)]
 pub enum BuildMode {
     /// Build the listed main package, plus all packages it imports,
@@ -420,15 +421,26 @@ impl std::fmt::Display for Error {
 }
 
 fn get_cc() -> PathBuf {
-    cc::Build::new().get_compiler().path().to_path_buf()
+    #[cfg(not( target_os = "windows" ))]
+    return cc::Build::new().get_compiler().path().to_path_buf();
+    #[cfg( target_os = "windows" )]
+    return cc::Build::new().target("x86_64-pc-windows-gnu").get_compiler().path().to_path_buf();
 }
 
 fn get_cxx() -> PathBuf {
-    cc::Build::new()
-        .cpp(true)
-        .get_compiler()
-        .path()
-        .to_path_buf()
+    #[cfg(not( target_os = "windows" ))]
+    return cc::Build::new()
+            .cpp(true)
+            .get_compiler()
+            .path()
+            .to_path_buf();
+    #[cfg( target_os = "windows" )]
+    return cc::Build::new()
+            .cpp(true)
+            .target("x86_64-pc-windows-gnu")
+            .get_compiler()
+            .path()
+            .to_path_buf();
 }
 
 fn goarch_from_env() -> Result<String, Error> {


### PR DESCRIPTION
Fix:
- go build won't download dependencies in windows platform
- only search MinGW toolchain when msvc and MinGW install at the same time because of cgo don't support msvc
- fix the library suffix

I build it in windows platform very hardly. Maybe others problem still exists.

Signed-off-by: Fu Lin <river@vvl.me>